### PR TITLE
🚸 Improve error handling for UX

### DIFF
--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -83,7 +83,7 @@ class LocalScheduler(Scheduler):
         result = await self.submit(job)
 
         if isinstance(result, Exception):
-            if isinstance(result, DependencyNeverSatisfiedException):
+            if isinstance(result, DependencyNeverSatisfiedError):
                 return result
             elif status == 'success':
                 return result
@@ -91,7 +91,7 @@ class LocalScheduler(Scheduler):
                 return None
         else:
             if status == 'failure':
-                return JobNotFailedException(f'{job}')
+                return JobNotFailedError(f'{job}')
             else:
                 return result
 
@@ -110,7 +110,7 @@ class LocalScheduler(Scheduler):
 
                 if isinstance(result, Exception):
                     if job.waitfor == 'all':
-                        raise DependencyNeverSatisfiedException(f'aborting job \'{job}\'') from result
+                        raise DependencyNeverSatisfiedError(f'aborting job \'{job}\'') from result
                 else:
                     if job.waitfor == 'any':
                         break
@@ -119,7 +119,7 @@ class LocalScheduler(Scheduler):
             break
         else:
             if job.dependencies and job.waitfor == 'any':
-                raise DependencyNeverSatisfiedException(f'aborting job \'{job}\'')
+                raise DependencyNeverSatisfiedError(f'aborting job \'{job}\'')
 
         # Execute job
         if job.empty:
@@ -204,7 +204,7 @@ class SlurmScheduler(Scheduler):
 
         for jobid in jobids:
             if isinstance(jobid, Exception):
-                raise DependencyNeverSatisfiedException(f'aborting job \'{job}\'') from jobid
+                raise DependencyNeverSatisfiedError(f'aborting job \'{job}\'') from jobid
 
         # Write submission file
         lines = [
@@ -307,11 +307,11 @@ class CyclicDependencyGraphError(Exception):
     pass
 
 
-class DependencyNeverSatisfiedException(Exception):
+class DependencyNeverSatisfiedError(Exception):
     pass
 
 
-class JobNotFailedException(Exception):
+class JobNotFailedError(Exception):
     pass
 
 

--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -292,7 +292,7 @@ class SlurmScheduler(Scheduler):
 
             return jobid
         except Exception as e:
-            raise SlurmSubmissionError(e)
+            return SlurmSubmissionError(e)
 
 
 

--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -193,6 +193,9 @@ class SlurmScheduler(Scheduler):
             for dep in job.dependencies
         ])
 
+        # Check if something went wrong during the submission of the dependencies
+        assert all([type(jobid) is str and jobid.isnumeric() for jobid in jobids]), 'failed to procure dependencies from sbatch'
+
         # Write submission file
         lines = [
             f'#!{self.shell}',

--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -54,7 +54,12 @@ class Scheduler(ABC):
         if job not in self.submissions:
             self.submissions[job] = asyncio.create_task(self._submit(job))
 
-        return await self.submissions[job]
+        try:
+            result = await self.submissions[job]
+        except Exception as error:
+            result = error
+
+        return result
 
     @abstractmethod
     async def _submit(self, job: Job) -> Any:
@@ -74,7 +79,7 @@ class LocalScheduler(Scheduler):
                 return None
         else:
             if status == 'failure':
-                raise JobNotFailedException(f'{job}')
+                return JobNotFailedException(f'{job}')
             else:
                 return result
 

--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -4,6 +4,7 @@ import asyncio
 import cloudpickle as pkl
 import os
 import shutil
+import traceback
 
 from abc import ABC, abstractmethod
 from datetime import datetime
@@ -15,12 +16,50 @@ from .utils import to_thread
 from .workflow import Job, cycles, prune as _prune
 
 
+class Scheduler(ABC):
+    r"""Abstract workflow scheduler"""
+
+    def __init__(self):
+        self.submissions = {}
+
+    async def gather(self, *jobs) -> List[Any]:
+        results = await asyncio.gather(*map(self.submit, jobs))
+
+        collect = []
+
+        for result in results:
+            if isinstance(result, Exception):
+                try:
+                    raise result
+                except:
+                    collect.append(traceback.format_exc())
+
+        if collect:
+            sep = '-' * 80 + '\n'
+            print(sep + sep.join(collect) + sep, end='')
+
+        return results
+
+    async def submit(self, job: Job) -> Any:
+        if job not in self.submissions:
+            self.submissions[job] = asyncio.create_task(self._submit(job))
+
+        try:
+            return await self.submissions[job]
+        except Exception as e:
+            return e
+
+    @abstractmethod
+    async def _submit(self, job: Job) -> Any:
+        pass
+
+
 def schedule(
     *jobs,
     backend: str,
     prune: bool = False,
     **kwargs,
-) -> List[Any]:
+) -> Scheduler:
     for cycle in cycles(*jobs, backward=True):
         raise CyclicDependencyGraphError(' <- '.join(map(str, cycle)))
 
@@ -32,38 +71,9 @@ def schedule(
         'slurm': SlurmScheduler,
     }.get(backend)(**kwargs)
 
-    return asyncio.run(scheduler.gather(*jobs))
+    asyncio.run(scheduler.gather(*jobs))
 
-
-class Scheduler(ABC):
-    r"""Abstract workflow scheduler"""
-
-    def __init__(self):
-        self.submissions = {}
-
-    async def gather(self, *jobs) -> List[Any]:
-        results = await asyncio.gather(*map(self.submit, jobs))
-
-        for result in results:
-            if isinstance(result, Exception):
-                raise result
-
-        return results
-
-    async def submit(self, job: Job) -> Any:
-        if job not in self.submissions:
-            self.submissions[job] = asyncio.create_task(self._submit(job))
-
-        try:
-            result = await self.submissions[job]
-        except Exception as error:
-            result = error
-
-        return result
-
-    @abstractmethod
-    async def _submit(self, job: Job) -> Any:
-        pass
+    return scheduler
 
 
 class LocalScheduler(Scheduler):
@@ -73,7 +83,9 @@ class LocalScheduler(Scheduler):
         result = await self.submit(job)
 
         if isinstance(result, Exception):
-            if status == 'success':
+            if isinstance(result, DependencyNeverSatisfiedException):
+                return result
+            elif status == 'success':
                 return result
             else:
                 return None
@@ -98,7 +110,7 @@ class LocalScheduler(Scheduler):
 
                 if isinstance(result, Exception):
                     if job.waitfor == 'all':
-                        raise DependencyNeverSatisfiedException(f'aborting job {job}') from result
+                        raise DependencyNeverSatisfiedException(f'aborting job \'{job}\'') from result
                 else:
                     if job.waitfor == 'any':
                         break
@@ -107,21 +119,18 @@ class LocalScheduler(Scheduler):
             break
         else:
             if job.dependencies and job.waitfor == 'any':
-                raise DependencyNeverSatisfiedException(f'aborting job {job}')
+                raise DependencyNeverSatisfiedException(f'aborting job \'{job}\'')
 
         # Execute job
-        try:
-            if job.empty:
-                return None
-            elif job.array is None:
-                return await to_thread(job.fn)
-            else:
-                return await asyncio.gather(*(
-                    to_thread(job.fn, i)
-                    for i in job.array
-                ))
-        except Exception as error:
-            return error
+        if job.empty:
+            return None
+        elif job.array is None:
+            return await to_thread(job.fn)
+        else:
+            return await asyncio.gather(*(
+                to_thread(job.fn, i)
+                for i in job.array
+            ))
 
 
 class SlurmScheduler(Scheduler):
@@ -193,9 +202,9 @@ class SlurmScheduler(Scheduler):
             for dep in job.dependencies
         ])
 
-        # Verify that sbatch was successful
-        exceptions = list(filter(lambda x: type(x) is Exception, jobids))
-        assert len(exceptions) == 0, exceptions[0]
+        for jobid in jobids:
+            if isinstance(jobid, Exception):
+                raise DependencyNeverSatisfiedException(f'aborting job \'{job}\'') from jobid
 
         # Write submission file
         lines = [

--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -202,10 +202,9 @@ class SlurmScheduler(Scheduler):
             for dep in job.dependencies
         ])
 
-        # Verify that sbatch was successful for dependencies
-        submission_errors = list(filter(lambda x: type(x) is SlurmSubmissionError, jobids))
-        if len(submission_errors) > 0:
-            raise DependencyNeverSatisfiedException(f'aborting job \'{job}\'') from submission_errors[0]
+        for jobid in jobids:
+            if isinstance(jobid, Exception):
+                raise DependencyNeverSatisfiedException(f'aborting job \'{job}\'') from jobid
 
         # Write submission file
         lines = [
@@ -301,8 +300,7 @@ class SlurmScheduler(Scheduler):
 
             return jobid
         except Exception as e:
-            return SlurmSubmissionError(e)
-
+            raise SlurmSubmissionError(f'failed submitting job \'{job}\'') from e
 
 
 class CyclicDependencyGraphError(Exception):

--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -193,8 +193,9 @@ class SlurmScheduler(Scheduler):
             for dep in job.dependencies
         ])
 
-        # Check if something went wrong during the submission of the dependencies
-        assert all([type(jobid) is str and jobid.isnumeric() for jobid in jobids]), 'failed to procure dependencies from sbatch'
+        # Verify that sbatch was successful
+        exceptions = list(filter(lambda x: type(x) is Exception, jobids))
+        assert len(exceptions) == 0, exceptions[0]
 
         # Write submission file
         lines = [


### PR DESCRIPTION
Consider the following workflow.

```python
from dawgz import job, after, waitfor, require, ensure, schedule, leafs

@job(array=2)
def a(i: int):
    print('a')

@after(a, status='failure')
@job
def a_fail():
    print('handling fail of a')

@after(a, status='success')
@job
def b():
    print('b')

schedule(*leafs(a), backend='local')
```
A user would expect the following output to `stdout`, since this is what Slurm would generate if you combine the generated logfiles.
```
a
a
b

# something about JotNotFailedException for a_fail `
```
However, with the `LocalScheduler` backend we get
```
a
a
Traceback (most recent call last):
  File "/home/joeri/Workspace/dawgz/test.py", line 32, in <module>
    results = schedule(*leafs(a), backend='local')
  File "/home/joeri/Workspace/dawgz/dawgz/schedulers.py", line 35, in schedule
    return asyncio.run(scheduler.gather(*jobs))
  File "/home/joeri/Anaconda/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/home/joeri/Anaconda/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/home/joeri/Workspace/dawgz/dawgz/schedulers.py", line 45, in gather
    results = await asyncio.gather(*map(self.submit, jobs))
  File "/home/joeri/Workspace/dawgz/dawgz/schedulers.py", line 57, in submit
    return await self.submissions[job]
  File "/home/joeri/Workspace/dawgz/dawgz/schedulers.py", line 92, in _submit
    result = task.result()
  File "/home/joeri/Workspace/dawgz/dawgz/schedulers.py", line 77, in condition
    raise JobNotFailedException(f'{job}')
dawgz.schedulers.JobNotFailedException: a[0:10:1]
```
Note that `b` is not executed. This PR implements the expected behavior.
