### PR TITLE
⚡️ Detect unsatisfiable dependencies while pruning

### DIFF
--- a/dawgz/__init__.py
+++ b/dawgz/__init__.py
@@ -47,8 +47,3 @@ def ensure(condition: Callable) -> Callable:
         return self
 
     return decorator
-
-
-def empty(self: Job) -> Job:
-    self.f = None
-    return self

--- a/dawgz/utils.py
+++ b/dawgz/utils.py
@@ -6,7 +6,7 @@ import traceback
 
 from functools import partial, lru_cache
 from inspect import signature
-from typing import Any, Callable, Coroutine, Iterable, List
+from typing import Any, Callable, Iterable, List
 
 
 @lru_cache(maxsize=None, typed=True)

--- a/dawgz/utils.py
+++ b/dawgz/utils.py
@@ -6,7 +6,7 @@ import traceback
 
 from functools import partial, lru_cache
 from inspect import signature
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Coroutine, Iterable, List
 
 
 @lru_cache(maxsize=None, typed=True)
@@ -20,6 +20,34 @@ def accepts(f: Callable, *args, **kwargs) -> bool:
         return False
     else:
         return True
+
+
+def comma_separated(integers: Iterable[int]) -> str:
+    r"""Formats integers as a comma separated list of intervals."""
+
+    integers = sorted(list(integers))
+    intervals = []
+
+    i = j = integers[0]
+
+    for k in integers[1:]:
+        if  k > j + 1:
+            intervals.append((i, j))
+            i = j = k
+        else:
+            j = k
+    else:
+        intervals.append((i, j))
+
+    fmt = lambda i, j: f'{i}' if i == j else f'{i}-{j}'
+
+    return ','.join(map(fmt, *zip(*intervals)))
+
+
+def every(conditions: List[Callable]) -> Callable:
+    r"""Combines a list of conditions into a single condition."""
+
+    return lambda *args: all(c(*args) for c in conditions)
 
 
 def print_traces(errors: Iterable[Exception]) -> None:

--- a/dawgz/workflow.py
+++ b/dawgz/workflow.py
@@ -1,9 +1,9 @@
 r"""Workflow graph components"""
 
-from functools import lru_cache
-from typing import Any, Callable, Dict, Iterator, List, Set, Tuple, Union
+from functools import cached_property
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Set, Tuple, Union
 
-from .utils import accepts
+from .utils import accepts, comma_separated, every
 
 
 class Node(object):
@@ -53,19 +53,21 @@ class Job(Node):
         self,
         f: Callable,
         name: str = None,
-        array: Union[int, Set[int], range] = None,
+        array: Union[int, Iterable[int]] = None,
         env: List[str] = [],
         settings: Dict[str, Any] = {},
         **kwargs,
     ):
         super().__init__(f.__name__ if name is None else name)
 
-        if type(array) is int:
-            array = range(array)
-
         if array is None:
             assert accepts(f), 'job should not expect arguments'
         else:
+            if type(array) is int:
+                array = range(array)
+            array = set(array)
+
+            assert len(array) > 0, 'array should not be empty'
             assert accepts(f, 0), 'job array should expect one argument'
 
         self.f = f
@@ -85,19 +87,15 @@ class Job(Node):
         self.preconditions = []
         self.postconditions = []
 
-    @property
-    def empty(self) -> bool:
-        return self.f is None or (self.array is not None and len(self.array) == 0)
+        # Pruning
+        self.unsatisfiable = False
 
     @property
     def fn(self) -> Callable:
         name, f = self.name, self.f
 
-        if f is None:
-            f = lambda *_: None
-
-        pre = self.reduce(self.preconditions)
-        post = self.reduce(self.postconditions)
+        pre = every(self.preconditions)
+        post = every(self.postconditions)
 
         def call(*args) -> Any:
             assert pre(*args), f'{name} does not satisfy its preconditions'
@@ -112,17 +110,10 @@ class Job(Node):
         return self.fn(*args)
 
     def __repr__(self) -> str:
-        if self.array is not None:
-            array = self.array
-
-            if type(array) is range:
-                array = f'[{array.start}:{array.stop}:{array.step}]'
-            else:
-                array = '[' + ','.join(map(str, array)) + ']'
+        if self.array is None:
+            return self.name
         else:
-            array = ''
-
-        return self.name + array
+            return self.name + '[' + comma_separated(self.array) + ']'
 
     @property
     def dependencies(self) -> Dict['Job', str]:
@@ -169,25 +160,17 @@ class Job(Node):
 
         self.postconditions.append(condition)
 
-    def reduce(self, conditions: List[Callable]) -> Callable:
-        if self.array is None:
-            return lambda: all(c() for c in conditions)
-        else:
-            return lambda i: all(c(i) for c in conditions)
-
-    @lru_cache(None)
-    def done(self, i: int = None) -> bool:
+    @cached_property
+    def done(self) -> bool:
         if not self.postconditions:
             return False
 
-        condition = self.reduce(self.postconditions)
+        condition = every(self.postconditions)
 
         if self.array is None:
             return condition()
-        elif i is None:
-            return all(map(condition, self.array))
         else:
-            return condition(i)
+            return all(map(condition, self.array))
 
 
 def dfs(*nodes, backward: bool = False) -> Iterator[Node]:
@@ -252,29 +235,36 @@ def cycles(*nodes, backward: bool = False) -> Iterator[List[Node]]:
 
 def prune(*jobs) -> List[Job]:
     for job in dfs(*jobs, backward=True):
-        if job.done():
-            job.f = None
+        if job.done:
             job.detach(*job.dependencies)
         elif job.array is not None:
-            pending = {
+            condition = every(job.postconditions)
+            job.array = {
                 i for i in job.array
-                if not job.done(i)
+                if not condition(i)
             }
 
-            if len(pending) < len(job.array):
-                job.array = pending
+        pending, satisfied, never_satisfied = [], [], []
 
-        done = {
-            dep for dep, status in job.dependencies.items()
-            if dep.done() and status != 'failure'
-        }
+        for dep, status in job.dependencies.items():
+            if dep.done:
+                if status == 'failure':
+                    never_satisfied.append(dep)
+                else:
+                    satisfied.append(dep)
+            else:
+                pending.append(dep)
 
-        if job.waitfor == 'any' and done:
-            job.detach(*job.dependencies)
-        elif job.waitfor == 'all':
-            job.detach(*done)
+        job.detach(*satisfied, *never_satisfied)
+
+        if job.waitfor == 'all' and never_satisfied:
+            job.unsatisfiable = True
+        elif job.waitfor == 'any' and never_satisfied and not pending:
+            job.unsatisfiable = True
+        elif job.waitfor == 'any' and satisfied:
+            job.detach(*pending)
 
     return [
         job for job in jobs
-        if not job.done()
+        if not job.done
     ]

--- a/dawgz/workflow.py
+++ b/dawgz/workflow.py
@@ -244,6 +244,9 @@ def prune(*jobs) -> Set[Job]:
                 if not condition(i)
             }
 
+        if not job.dependencies:
+            continue
+
         pending, satisfied, never_satisfied = [], [], []
 
         for dep, status in job.dependencies.items():
@@ -255,13 +258,13 @@ def prune(*jobs) -> Set[Job]:
             else:
                 pending.append(dep)
 
-        job.detach(*satisfied, *never_satisfied)
+        job.detach(*satisfied)
 
         if job.waitfor == 'all' and never_satisfied:
             job.unsatisfiable = True
         elif job.waitfor == 'any' and satisfied:
-            job.detach(*pending)
-        elif job.waitfor == 'any' and never_satisfied and not pending:
+            job.detach(*pending, *never_satisfied)
+        elif job.waitfor == 'any' and not pending:
             job.unsatisfiable = True
 
     return {

--- a/dawgz/workflow.py
+++ b/dawgz/workflow.py
@@ -233,7 +233,7 @@ def cycles(*nodes, backward: bool = False) -> Iterator[List[Node]]:
         visited.add(node)
 
 
-def prune(*jobs) -> List[Job]:
+def prune(*jobs) -> Set[Job]:
     for job in dfs(*jobs, backward=True):
         if job.done:
             job.detach(*job.dependencies)
@@ -259,12 +259,12 @@ def prune(*jobs) -> List[Job]:
 
         if job.waitfor == 'all' and never_satisfied:
             job.unsatisfiable = True
-        elif job.waitfor == 'any' and never_satisfied and not pending:
-            job.unsatisfiable = True
         elif job.waitfor == 'any' and satisfied:
             job.detach(*pending)
+        elif job.waitfor == 'any' and never_satisfied and not pending:
+            job.unsatisfiable = True
 
-    return [
+    return {
         job for job in jobs
         if not job.done
-    ]
+    }


### PR DESCRIPTION
I added an `unsatisfiable` attribute to jobs such that schedulers directly return `DepencyNeverSatifiedError` when submitting such jobs. Unlike #3, I don't remove all unsatisfiable nodes from the graph. Instead, I let the `DepencyNeverSatifiedError` propagate through the graph during scheduling, which creates understandable error traces.