### PR TITLE
🐛 Unsatisfied dependencies are never detached

### DIFF
--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -53,7 +53,7 @@ class Scheduler(ABC):
         if job in self.submissions:
             task = self.submissions[job]
         else:
-            if job.unsatisfiable:
+            if not job.satisfiable:
                 try:
                     raise DependencyNeverSatisfiedError(f'aborting {job}')
                 except Exception as e:


### PR DESCRIPTION
In the current implementation, unsatisfied dependencies are never detached from the graph. As a result, if `waitfor='any'`, they are still executed. For instance, the following example executes `b` even though it should not.

```python
from dawgz import job, after, waitfor, ensure, schedule

@job
def a():
    print('a')

@ensure(lambda: 1 == 1)
@job
def b():
    print('b')

@after(a)
@after(b, status='failure')
@waitfor('any')
@job
def c():
    print('c')

schedule(c, backend='local', prune=True)
```

This PR fixes the issue.
