### PR TITLE
Make compatible with Python3.11+

### DIFF
--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -129,8 +129,8 @@ class Scheduler(ABC):
 
     async def _wait(self, *jobs: Job) -> None:
         if jobs:
-            await asyncio.wait(map(self.submit, jobs))
-            await asyncio.wait(map(self.submit, self.order))
+            await asyncio.wait(map(asyncio.create_task, map(self.submit, jobs)))
+            await asyncio.wait(map(asyncio.create_task, map(self.submit, self.order)))
 
     async def submit(self, job: Job) -> Any:
         if job in self.results:


### PR DESCRIPTION
Based on https://github.com/AngellusMortis/pyunifiprotect/pull/284

Needed becasue
```
Changed in version 3.11: Passing coroutine objects to wait() directly is forbidden.
```
Source: https://docs.python.org/3/library/asyncio-task.html#waiting-primitives