### PR TITLE
Add setting the maximum number of simultaneous tasks for a job

### DIFF
--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -399,8 +399,8 @@ class SlurmScheduler(Scheduler):
 
         if job.array is not None:
             arrayline = "#SBATCH --array=" + comma_separated(job.array)
-            if "simtasks" in self.settings:
-                arrayline += f"%{self.settings['simtasks']}"
+            if "simtasks" in job.settings:
+                arrayline += f"%{job.settings['simtasks']}"
             lines.append(arrayline)
 
         tag = self.tag(job)

--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -415,7 +415,6 @@ class SlurmScheduler(Scheduler):
         ## Settings
         settings = self.settings.copy()
         settings.update(job.settings)
-        settings.pop("simtasks", None)
 
         assert 'clusters' not in settings, "multi-cluster operations not supported"
 

--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -415,6 +415,7 @@ class SlurmScheduler(Scheduler):
         ## Settings
         settings = self.settings.copy()
         settings.update(job.settings)
+        settings.pop("simtasks", None)
 
         assert 'clusters' not in settings, "multi-cluster operations not supported"
 

--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -398,10 +398,10 @@ class SlurmScheduler(Scheduler):
         ]
 
         if job.array is not None:
-            arrayline = "#SBATCH --array=" + comma_separated(job.array)
-            if "simtasks" in job.settings:
-                arrayline += f"%{job.settings['simtasks']}"
-            lines.append(arrayline)
+            line = "#SBATCH --array=" + comma_separated(job.array)
+            if 'maxsim' in job.settings:
+                line += f"%{job.settings.pop('maxsim')}"
+            lines.append(line)
 
         tag = self.tag(job)
 

--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -398,7 +398,10 @@ class SlurmScheduler(Scheduler):
         ]
 
         if job.array is not None:
-            lines.append("#SBATCH --array=" + comma_separated(job.array))
+            arrayline = "#SBATCH --array=" + comma_separated(job.array)
+            if "simtasks" in self.settings:
+                arrayline += f"%{self.settings['simtasks']}"
+            lines.append(arrayline)
 
         tag = self.tag(job)
 


### PR DESCRIPTION
### Description

This pull request adds a simple job parameter that allows for setting the number of tasks simultaneously running for a given job.

By default, this is unbounded and can result in undesired behavior on clusters with no per-user limit. Using this parameter, one can voluntarily decide to run at most `N` processes at a time, and stop worrying about using the whole cluster when many jobs must be run.

### Usage

One simply has to set the parameter `simtasks`, which stands for *simultaneous tasks*, to some integer value in the `job` decorator.

__Example__:
```python
from dawgz import job, schedule                                                                                                                                                             
from time import sleep                                                                                                                                                                      
                                                                                                                                                                                              
@job(array=20, simtasks=3)                                                                                                                                                                
def example(i):                                                                                                                                                                             
    sleep(i)                                                                                                                                                                                                                                                                                                                                                                    
    print(i)                                                                                                                                                                                
                                                                                                                                                                                            
if __name__ == "__main__":                                                                                                                                                                  
    schedule(example, backend="slurm") 
```

This code will submit a job with the following IDs
```
<firstjobid>_[0-19%3]
```
and at most 3 jobs will run simultaneously.

### References
Slurm documentation: https://slurm.schedmd.com/job_array.html