### PR TITLE
🩹 Ignore UTF-8 decoding errors in CLI outputs (Slurm)

### DIFF
--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -380,7 +380,7 @@ class SlurmScheduler(Scheduler):
             logfile = self.path / f"{tag}_{i}.log"
 
         if logfile.exists():
-            with open(logfile, newline="") as f:
+            with open(logfile, newline="", errors="ignore") as f:
                 return f.read()
         else:
             return None

--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -380,7 +380,7 @@ class SlurmScheduler(Scheduler):
             logfile = self.path / f"{tag}_{i}.log"
 
         if logfile.exists():
-            with open(logfile, newline="", errors="ignore") as f:
+            with open(logfile, newline="", errors="replace") as f:
                 return f.read()
         else:
             return None


### PR DESCRIPTION
Most likely due to some tqdm output (or faulty output more generally), the output of some jobs would not be printed correctly and instead raises a decoding error.

This PR simply ignores errors when decoding the output of Slurm logs.

---

Example error before:
```
Traceback (most recent call last):
  File /home/sach/micromamba/envs/coucou/bin/dawgz", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/sach/dawgz/dawgz/__main__.py", line 74, in main
    table(workflows, args.workflow, args.job, args.array)
  File "/home/sach/dawgz/dawgz/__main__.py", line 28, in table
    table = scheduler.report(job, array)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sach/dawgz/dawgz/schedulers.py", line 407, in report
    return super().report(job, array_idx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sach/dawgz/dawgz/schedulers.py", line 126, in report
    rows = [
           ^
  File "/home/sach/dawgz/dawgz/schedulers.py", line 127, in <listcomp>
    (f"{job.name}[{i}]", self.state(job, i), self.output(job, i)) for i in array
                                             ^^^^^^^^^^^^^^^^^^^
  File "/home/sach/dawgz/dawgz/schedulers.py", line 388, in output
    return f.read()
           ^^^^^^^^
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 125986-125987: invalid continuation byte
```