### PR TITLE
✨  Add job-bound interpreters

### DIFF
--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -522,7 +522,7 @@ class SlurmScheduler(Scheduler):
                 ])
             )
 
-        if self.interpreter is not None:
+        if job.interpreter is None:
             interpreter = self.interpreter
         else:
             interpreter = job.interpreter

--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -319,7 +319,7 @@ class SlurmScheduler(Scheduler):
         self,
         name: str = None,
         shell: str = os.environ.get("SHELL", "/bin/sh"),
-        interpreter: str = "python",
+        interpreter: str = None,
         env: Sequence[str] = [],  # noqa: B006
         **kwargs,
     ):
@@ -327,7 +327,7 @@ class SlurmScheduler(Scheduler):
         Arguments:
             name: The name of the workflow.
             shell: The scripting shell.
-            interpreter: The Python interpreter.
+            interpreter: The Python interpreter. If not None, overrides jobs' interpreters.
             env: A sequence of commands to execute before each job is launched.
             kwargs: Keyword arguments passed to :class:`Scheduler`.
         """
@@ -522,10 +522,15 @@ class SlurmScheduler(Scheduler):
                 ])
             )
 
-        if job.array is None:
-            lines.append(f"srun {self.interpreter} {pyfile}")
+        if self.interpreter is not None:
+            interpreter = self.interpreter
         else:
-            lines.append(f"srun {self.interpreter} {pyfile} -i $SLURM_ARRAY_TASK_ID")
+            interpreter = job.interpreter
+
+        if job.array is None:
+            lines.append(f"srun {interpreter} {pyfile}")
+        else:
+            lines.append(f"srun {interpreter} {pyfile} -i $SLURM_ARRAY_TASK_ID")
 
         lines.append("")
 

--- a/dawgz/schedulers.py
+++ b/dawgz/schedulers.py
@@ -319,7 +319,7 @@ class SlurmScheduler(Scheduler):
         self,
         name: str = None,
         shell: str = os.environ.get("SHELL", "/bin/sh"),
-        interpreter: str = None,
+        interpreter: str = "python",
         env: Sequence[str] = [],  # noqa: B006
         **kwargs,
     ):
@@ -327,7 +327,7 @@ class SlurmScheduler(Scheduler):
         Arguments:
             name: The name of the workflow.
             shell: The scripting shell.
-            interpreter: The Python interpreter. If not None, overrides jobs' interpreters.
+            interpreter: The Python interpreter.
             env: A sequence of commands to execute before each job is launched.
             kwargs: Keyword arguments passed to :class:`Scheduler`.
         """

--- a/dawgz/workflow.py
+++ b/dawgz/workflow.py
@@ -42,7 +42,7 @@ class Job(Node):
         name: str = None,
         array: Union[int, Iterable[int]] = None,
         array_throttle: int = None,
-        interpreter: str = "python",
+        interpreter: str = None,
         settings: Dict[str, Any] = {},  # noqa: B006
         **kwargs,
     ):

--- a/dawgz/workflow.py
+++ b/dawgz/workflow.py
@@ -42,6 +42,7 @@ class Job(Node):
         name: str = None,
         array: Union[int, Iterable[int]] = None,
         array_throttle: int = None,
+        interpreter: str = "python",
         settings: Dict[str, Any] = {},  # noqa: B006
         **kwargs,
     ):
@@ -63,6 +64,7 @@ class Job(Node):
         self.name = f.__name__ if name is None else name
         self.array = array
         self.array_throttle = array_throttle
+        self.interpreter = interpreter
 
         # Settings
         self.settings = settings.copy()


### PR DESCRIPTION
This PR slightly changes the interpreter setting so it can be set at the job level.

If set at the scheduler level, it will override the interpreter of every job, otherwise, it will use each job's interpreter. This notably allows for using Torchrun for some jobs in the workflow and use Python for other jobs, such as generating on multiple GPUs and aggregating on a single one :-) 